### PR TITLE
Remove redundant seg-id attributes

### DIFF
--- a/dita_xml_parser/transformer.py
+++ b/dita_xml_parser/transformer.py
@@ -128,10 +128,9 @@ class Dita2LLM:
             placeholder_map[placeholder] = elem.tag
             new_tag = placeholder
             seg_id = elem.get('data-dita-seg-id')
-            # strip attributes except seg id
+            # strip all attributes; seg id will be encoded in the tag name
             for attr in list(elem.attrib):
-                if attr != 'data-dita-seg-id':
-                    del elem.attrib[attr]
+                del elem.attrib[attr]
             if seg_id:
                 new_tag = f"{placeholder}_{seg_id}"
             elem.tag = new_tag


### PR DESCRIPTION
## Summary
- clean up minimal XML generation
- remove `data-dita-seg-id` attributes because IDs are encoded in tag names

## Testing
- `pip install -q -r requirements.txt`
- `python - <<'PY'
from dita_xml_parser import Dita2LLM
transformer=Dita2LLM('sample_data','intermediate','translated',log_dir='logs')
segments,_=transformer.parse('sample_data/sample_topic.xml')
print(open('intermediate/sample_topic.minimal.xml').read())
PY`

------
https://chatgpt.com/codex/tasks/task_e_6840af35e2b8832087a03524d4968ec0