### PR TITLE
Add complex DITA samples and tests

### DIFF
--- a/sample_data/complex_topic.xml
+++ b/sample_data/complex_topic.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="complex_topic">
+  <title>Complex Topic</title>
+  <body>
+    <p>Beginning text
+      <ul>
+        <li>Item 0</li>
+        <li>Item <i>1</i></li>
+      </ul>
+      some mid text <i>inline</i> element
+    </p>
+    <p>Paragraph with <b>bold <i>and italic</i></b> nested tags.</p>
+    <section id="sub1">
+      <title>Subsection</title>
+      <p>Subsection <u>underlined</u> text.</p>
+    </section>
+  </body>
+</topic>

--- a/sample_data/sample_map.ditamap
+++ b/sample_data/sample_map.ditamap
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+  <title>Sample Map</title>
+  <topicref href="sample_topic.xml" />
+  <topicref href="complex_topic.xml" />
+  <topicref href="simple_concept.xml" />
+</map>

--- a/sample_data/simple_concept.xml
+++ b/sample_data/simple_concept.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
+<concept id="simple_concept">
+  <title>Simple Concept</title>
+  <conbody>
+    <p>This concept references <xref href="complex_topic.xml">complex topic</xref>.</p>
+  </conbody>
+</concept>

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -1,0 +1,63 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import json
+from lxml import etree
+from dita_xml_parser import Dita2LLM
+import config
+
+COMPLEX_TOPIC = os.path.join(os.path.dirname(__file__), '..', 'sample_data', 'complex_topic.xml')
+SIMPLE_CONCEPT = os.path.join(os.path.dirname(__file__), '..', 'sample_data', 'simple_concept.xml')
+SAMPLE_MAP = os.path.join(os.path.dirname(__file__), '..', 'sample_data', 'sample_map.ditamap')
+
+
+def make_transformer(tmp_path):
+    intermediate = tmp_path / 'intermediate'
+    target = tmp_path / 'translated'
+    intermediate.mkdir()
+    target.mkdir()
+    return Dita2LLM('sample_data', str(intermediate), str(target))
+
+
+def test_nested_paragraph_inner_xml(tmp_path):
+    tr = make_transformer(tmp_path)
+    parser = etree.XMLParser(remove_blank_text=False)
+    tree = etree.parse(COMPLEX_TOPIC, parser)
+    p_elem = tree.xpath('//p')[0]
+    inner = tr._get_inner_xml(p_elem)
+    assert 'Beginning text' in inner
+    assert '<ul>' in inner
+    assert 'some mid text' in inner
+    tr._set_inner_xml(p_elem, inner)
+    assert tr._get_inner_xml(p_elem) == inner
+
+
+def test_complex_topic_parse_and_validate(tmp_path):
+    tr = make_transformer(tmp_path)
+    segments, skeleton = tr.parse(COMPLEX_TOPIC)
+    # ensure multiple segments detected
+    assert len(segments) >= 5
+    seg_path = tmp_path / 'intermediate' / 'complex_topic.en-US_segments.json'
+    dummy_path = tmp_path / 'intermediate' / 'complex_topic.translated.json'
+    tr.generate_dummy_translation(str(seg_path), str(dummy_path))
+    target_path = tr.integrate(str(dummy_path))
+    report = tr.validate(COMPLEX_TOPIC, target_path)
+    assert report.passed
+
+
+def test_concept_parse_and_validate(tmp_path):
+    tr = make_transformer(tmp_path)
+    segments, skeleton = tr.parse(SIMPLE_CONCEPT)
+    seg_path = tmp_path / 'intermediate' / 'simple_concept.en-US_segments.json'
+    dummy_path = tmp_path / 'intermediate' / 'simple_concept.translated.json'
+    tr.generate_dummy_translation(str(seg_path), str(dummy_path))
+    target_path = tr.integrate(str(dummy_path))
+    report = tr.validate(SIMPLE_CONCEPT, target_path)
+    assert report.passed
+
+
+def test_map_parse(tmp_path):
+    tr = make_transformer(tmp_path)
+    segments, skeleton = tr.parse(SAMPLE_MAP)
+    seg_path = tmp_path / 'intermediate' / 'sample_map.en-US_segments.json'
+    assert os.path.exists(str(seg_path))
+    assert os.path.exists(str(skeleton))


### PR DESCRIPTION
## Summary
- add complex topic, concept, and map samples
- cover nested list and inline tags
- create comprehensive tests for parsing and validation of these new samples

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840b16ab3a083209239c87f06a5fda2