### PR TITLE
Add flexible path handling for transformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,45 @@ tr = Dita2LLM(
     target_dir="translated",
 )
 
-segments, skeleton = tr.parse("sample_data/sample_topic.xml")
+segments, skeleton = tr.parse("sample_topic.xml")  # filename only
 
 # Normally the segments would be sent for translation
 tr.generate_dummy_translation(
-    "intermediate/sample_topic.en-US_segments.json",
-    "intermediate/sample_topic.translated.json",
+    "sample_topic.en-US_segments.json",
+    "sample_topic.translated.json",
 )
 
 # Merge translations back into the skeleton
-tr.integrate("intermediate/sample_topic.translated.json")
+tr.integrate("sample_topic.translated.json")
 
 # Validate the result
-report = tr.validate("sample_data/sample_topic.xml", tr._last_target_path)
+report = tr.validate("sample_topic.xml", tr._last_target_path)
 print("validation", "passed" if report.passed else "failed")
 ```
 
 For simple workflows you can translate the generated `*.minimal.xml` and call `integrate_from_simple_xml` to reconstruct the original document.
+
+## Working with absolute paths
+
+When `source_dir`, `intermediate_dir`, and `target_dir` are left unset you can
+provide explicit paths to all methods. Output locations can also be overridden:
+
+```python
+from dita_xml_parser import Dita2LLM
+
+tr = Dita2LLM()  # no base directories
+
+xml_path = "/data/topic/sample_topic.xml"
+segments_path = "/tmp/sample_topic.segs.json"
+skeleton_path = "/tmp/sample_topic.skel.xml"
+tr.parse(xml_path, skeleton_path=skeleton_path, segments_path=segments_path)
+
+translated_path = "/tmp/sample_topic.translated.json"
+tr.generate_dummy_translation(segments_path, translated_path)
+
+out_xml = "/tmp/sample_topic.translated.xml"
+tr.integrate(translated_path, skeleton_path=skeleton_path, output_path=out_xml)
+
+report = tr.validate(xml_path, out_xml)
+print("validation", "passed" if report.passed else "failed")
+```

--- a/dita_xml_parser/transformer.py
+++ b/dita_xml_parser/transformer.py
@@ -1,6 +1,5 @@
 """Transformation utilities for preparing DITA XML for LLM translation."""
 
-
 from __future__ import annotations
 
 import datetime
@@ -30,9 +29,9 @@ class Dita2LLM:
 
     def __init__(
         self,
-        source_dir: str,
-        intermediate_dir: str,
-        target_dir: str,
+        source_dir: str | None = None,
+        intermediate_dir: str | None = None,
+        target_dir: str | None = None,
         source_lang: str = "en-US",
         target_lang: str = "de-DE",
         log_dir: str = "logs",
@@ -43,8 +42,10 @@ class Dita2LLM:
         self.source_lang = source_lang
         self.target_lang = target_lang
         self.log_dir = log_dir
-        os.makedirs(self.intermediate_dir, exist_ok=True)
-        os.makedirs(self.target_dir, exist_ok=True)
+        if self.intermediate_dir:
+            os.makedirs(self.intermediate_dir, exist_ok=True)
+        if self.target_dir:
+            os.makedirs(self.target_dir, exist_ok=True)
         os.makedirs(self.log_dir, exist_ok=True)
         self.logger = logging.getLogger("Dita2LLM")
         self.logger.setLevel(getattr(logging, config.LOG_LEVEL))
@@ -66,10 +67,24 @@ class Dita2LLM:
         self.logger.addHandler(fh)
         return log_path
 
+    def _resolve(self, path: str, base: str | None) -> str:
+        """Return ``path`` joined with ``base`` if it lacks directory info."""
 
-    def parse(self, xml_path: str) -> Tuple[List[dict], str]:
+        if os.path.isabs(path) or os.path.dirname(path):
+            return path
+        if base:
+            return os.path.join(base, path)
+        return path
+
+    def parse(
+        self,
+        xml_path: str,
+        skeleton_path: str | None = None,
+        segments_path: str | None = None,
+    ) -> Tuple[List[dict], str]:
         """Parse ``xml_path`` and produce JSON segments and a skeleton XML."""
 
+        xml_path = self._resolve(xml_path, self.source_dir)
         self._init_log(xml_path)
         self.logger.info("Start parse: %s", xml_path)
         with open(xml_path, "rb") as f:
@@ -96,9 +111,9 @@ class Dita2LLM:
                 ids.append((elem, seg_id))
                 count += 1
         base = os.path.splitext(os.path.basename(xml_path))[0]
-        skeleton_path = os.path.join(
-            self.intermediate_dir, f"{base}.skeleton.xml"
-        )
+        base_dir = self.intermediate_dir or os.path.dirname(skeleton_path or xml_path) or "."
+        if skeleton_path is None:
+            skeleton_path = os.path.join(base_dir, f"{base}.skeleton.xml")
         tree.write(
             skeleton_path,
             encoding=encoding,
@@ -107,25 +122,28 @@ class Dita2LLM:
         )
         segments = []
         for elem, seg_id in ids:
-            segments.append(
-                {"id": seg_id, self.source_lang: utils.get_inner_xml(elem)}
-            )
-        segments_path = os.path.join(
-            self.intermediate_dir, f"{base}.{self.source_lang}_segments.json"
-        )
+            segments.append({"id": seg_id, self.source_lang: utils.get_inner_xml(elem)})
+        if segments_path is None:
+            segments_path = os.path.join(base_dir, f"{base}.{self.source_lang}_segments.json")
         with open(segments_path, "w", encoding="utf-8") as f:
             json.dump(segments, f, indent=2, ensure_ascii=False)
-        minimal.write_minimal(tree, base, self.intermediate_dir, encoding, self.logger)
+        minimal.write_minimal(tree, base, base_dir, encoding, self.logger)
         self.logger.info("Containers found: %s", count)
         self.logger.info("JSON segments written: %s", len(segments))
         self.logger.info("Skeleton path: %s", skeleton_path)
+        self.logger.info("Segments path: %s", segments_path)
         self.logger.info("End parse")
         return segments, skeleton_path
 
-
-    def integrate(self, translation_json_path: str) -> str:
+    def integrate(
+        self,
+        translation_json_path: str,
+        skeleton_path: str | None = None,
+        output_path: str | None = None,
+    ) -> str:
         """Merge translated segments back into the skeleton XML."""
 
+        translation_json_path = self._resolve(translation_json_path, self.intermediate_dir)
         self.logger.info("Start integrate: %s", translation_json_path)
         with open(translation_json_path, "r", encoding="utf-8") as f:
             translations = json.load(f)
@@ -137,10 +155,11 @@ class Dita2LLM:
             base = name[: -(len(self.target_lang) + 12)]
         else:
             base = name.split(".")[0]
-        skeleton_path = os.path.join(
-            self.intermediate_dir,
-            f"{base}.skeleton.xml",
-        )
+        if skeleton_path is None:
+            skel_base = self.intermediate_dir or os.path.dirname(translation_json_path)
+            skeleton_path = os.path.join(skel_base, f"{base}.skeleton.xml")
+        else:
+            skeleton_path = self._resolve(skeleton_path, self.intermediate_dir)
         parser = etree.XMLParser(remove_blank_text=False)
         tree = etree.parse(skeleton_path, parser)
         root = tree.getroot()
@@ -162,7 +181,11 @@ class Dita2LLM:
         for el in root.iter():
             if "data-dita-seg-id" in el.attrib:
                 del el.attrib["data-dita-seg-id"]
-        target_path = os.path.join(self.target_dir, f"{base}.xml")
+        if output_path is None:
+            out_base = self.target_dir or os.path.dirname(skeleton_path)
+            target_path = os.path.join(out_base, f"{base}.xml")
+        else:
+            target_path = self._resolve(output_path, self.target_dir)
         tree.write(
             target_path,
             encoding="utf-8",
@@ -171,14 +194,16 @@ class Dita2LLM:
             pretty_print=True,
         )
         self._last_target_path = target_path
+        self.logger.info(f"Skeleton used: {skeleton_path}")
         self.logger.info(f"Wrote integrated file: {target_path}")
         self.logger.info("End integrate")
         return target_path
 
-
     def validate(self, src_xml: str, tgt_xml: str) -> ValidationReport:
         """Check that ``tgt_xml`` still structurally matches ``src_xml``."""
 
+        src_xml = self._resolve(src_xml, self.source_dir)
+        tgt_xml = self._resolve(tgt_xml, self.target_dir)
         self.logger.info("Start validate: %s vs %s", src_xml, tgt_xml)
         parser = etree.XMLParser(remove_blank_text=False)
         try:
@@ -204,9 +229,7 @@ class Dita2LLM:
                     errors.append(f"child count mismatch at {path}/{e1.tag}")
                 for c1, c2 in zip(children1, children2):
                     walk(c1, c2, path + "/" + e1.tag)
-            elif isinstance(e1, etree._Comment) and isinstance(
-                e2, etree._Comment
-            ):
+            elif isinstance(e1, etree._Comment) and isinstance(e2, etree._Comment):
                 if e1.text != e2.text:
                     errors.append(f"comment mismatch at {path}")
             elif isinstance(e1, etree._ProcessingInstruction) and isinstance(
@@ -222,9 +245,9 @@ class Dita2LLM:
         self.logger.info("End validate")
         return ValidationReport(passed, errors)
 
-    def generate_dummy_translation(
-        self, segments_json_path: str, output_path: str
-    ) -> str:
+    def generate_dummy_translation(self, segments_json_path: str, output_path: str) -> str:
+        segments_json_path = self._resolve(segments_json_path, self.intermediate_dir)
+        output_path = self._resolve(output_path, self.intermediate_dir)
         with open(segments_json_path, "r", encoding="utf-8") as f:
             segments = json.load(f)
         translations = []
@@ -262,6 +285,7 @@ class Dita2LLM:
         Tuple[str, ValidationReport]
             Path to the generated translated XML and the validation report.
         """
+        simple_xml_path = self._resolve(simple_xml_path, self.intermediate_dir)
         self.logger.info(f"Start integrate from simple XML: {simple_xml_path}")
 
         name = os.path.splitext(os.path.basename(simple_xml_path))[0]
@@ -270,31 +294,33 @@ class Dita2LLM:
         else:
             base = name
 
-        mapping_path = os.path.join(self.intermediate_dir, f"{base}.tag_mappings.txt")
-        skeleton_path = os.path.join(self.intermediate_dir, f"{base}.skeleton.xml")
-        source_xml_path = os.path.join(self.source_dir, f"{base}.xml")
+        base_dir = self.intermediate_dir or os.path.dirname(simple_xml_path)
+        mapping_path = os.path.join(base_dir, f"{base}.tag_mappings.txt")
+        skeleton_path = os.path.join(base_dir, f"{base}.skeleton.xml")
+        src_base = self.source_dir or os.path.dirname(simple_xml_path)
+        source_xml_path = os.path.join(src_base, f"{base}.xml")
 
         parser = etree.XMLParser(remove_blank_text=False)
         simple_tree = etree.parse(simple_xml_path, parser)
 
         mappings: Dict[str, str] = {}
-        with open(mapping_path, 'r', encoding='utf-8') as f:
+        with open(mapping_path, "r", encoding="utf-8") as f:
             for line in f:
-                if '->' in line:
-                    ph, tag = line.strip().split(' -> ')
+                if "->" in line:
+                    ph, tag = line.strip().split(" -> ")
                     mappings[ph] = tag
 
         # Replace placeholder tags with real tag names and capture seg ids
         for elem in simple_tree.getroot().iter():
             tag = elem.tag
             seg_id = None
-            if '_' in tag:
-                placeholder, seg_id = tag.split('_', 1)
+            if "_" in tag:
+                placeholder, seg_id = tag.split("_", 1)
             else:
                 placeholder = tag
             elem.tag = mappings.get(placeholder, placeholder)
             if seg_id:
-                elem.set('data-dita-seg-id', seg_id)
+                elem.set("data-dita-seg-id", seg_id)
 
         skeleton_tree = etree.parse(skeleton_path, parser)
         skeleton_root = skeleton_tree.getroot()
@@ -310,7 +336,7 @@ class Dita2LLM:
             used: List[etree._Element] = []
             for s_child in skel_elem:
                 match = None
-                sid = s_child.get('data-dita-seg-id')
+                sid = s_child.get("data-dita-seg-id")
                 if sid:
                     for c in trans_elem.xpath(f"*[@data-dita-seg-id='{sid}']"):
                         match = c
@@ -325,20 +351,26 @@ class Dita2LLM:
                     merge(match, s_child)
                     s_child.tail = match.tail
 
-        for seg_elem in simple_tree.getroot().xpath('//*[@data-dita-seg-id]'):
-            seg_id = seg_elem.get('data-dita-seg-id')
+        for seg_elem in simple_tree.getroot().xpath("//*[@data-dita-seg-id]"):
+            seg_id = seg_elem.get("data-dita-seg-id")
             match = skeleton_root.xpath(f"//*[@data-dita-seg-id='{seg_id}']")
             if match:
                 merge(seg_elem, match[0])
 
         for el in skeleton_root.iter():
-            if 'data-dita-seg-id' in el.attrib:
-                del el.attrib['data-dita-seg-id']
+            if "data-dita-seg-id" in el.attrib:
+                del el.attrib["data-dita-seg-id"]
 
-        target_path = os.path.join(self.target_dir, f"{base}.xml")
-        skeleton_tree.write(target_path, encoding='utf-8', xml_declaration=True, doctype=skeleton_tree.docinfo.doctype, pretty_print=True)
+        out_base = self.target_dir or base_dir
+        target_path = os.path.join(out_base, f"{base}.xml")
+        skeleton_tree.write(
+            target_path,
+            encoding="utf-8",
+            xml_declaration=True,
+            doctype=skeleton_tree.docinfo.doctype,
+            pretty_print=True,
+        )
         self._last_target_path = target_path
         report = self.validate(source_xml_path, target_path)
         self.logger.info("End integrate from simple XML")
         return target_path, report
-

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1,4 +1,5 @@
 import os, sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import json
 from lxml import etree
@@ -6,15 +7,15 @@ from dita_xml_parser import Dita2LLM
 from dita_xml_parser import utils
 import config
 
-SAMPLE_XML = os.path.join(os.path.dirname(__file__), '..', 'sample_data', 'sample_topic.xml')
+SAMPLE_XML = os.path.join(os.path.dirname(__file__), "..", "sample_data", "sample_topic.xml")
 
 
 def make_transformer(tmp_path):
-    intermediate = tmp_path / 'intermediate'
-    target = tmp_path / 'translated'
+    intermediate = tmp_path / "intermediate"
+    target = tmp_path / "translated"
     intermediate.mkdir()
     target.mkdir()
-    return Dita2LLM('sample_data', str(intermediate), str(target))
+    return Dita2LLM("sample_data", str(intermediate), str(target))
 
 
 def test_generate_id_length(tmp_path):
@@ -26,19 +27,19 @@ def test_generate_id_length(tmp_path):
 
 def test_is_container_and_inline(tmp_path):
     tr = make_transformer(tmp_path)
-    elem = etree.fromstring('<p>This is <b>bold</b></p>')
+    elem = etree.fromstring("<p>This is <b>bold</b></p>")
     assert utils.is_container(elem)
     assert utils.has_inline_child(elem)
-    inline = etree.fromstring('<b>bold</b>')
+    inline = etree.fromstring("<b>bold</b>")
     assert not utils.is_container(inline)
 
 
 def test_get_and_set_inner_xml(tmp_path):
     tr = make_transformer(tmp_path)
-    elem = etree.fromstring('<p>A <b>test</b></p>')
-    assert utils.get_inner_xml(elem) == 'A <b>test</b>'
-    utils.set_inner_xml(elem, 'Hello <i>World</i>')
-    assert etree.tostring(elem, encoding='unicode') == '<p>Hello <i>World</i></p>'
+    elem = etree.fromstring("<p>A <b>test</b></p>")
+    assert utils.get_inner_xml(elem) == "A <b>test</b>"
+    utils.set_inner_xml(elem, "Hello <i>World</i>")
+    assert etree.tostring(elem, encoding="unicode") == "<p>Hello <i>World</i></p>"
 
 
 def test_parse_creates_segments_and_files(tmp_path):
@@ -46,25 +47,25 @@ def test_parse_creates_segments_and_files(tmp_path):
     segments, skeleton = tr.parse(SAMPLE_XML)
     assert len(segments) == 9
     assert os.path.exists(skeleton)
-    seg_path = tmp_path / 'intermediate' / 'sample_topic.en-US_segments.json'
+    seg_path = tmp_path / "intermediate" / "sample_topic.en-US_segments.json"
     assert seg_path.exists()
-    minimal_path = tmp_path / 'intermediate' / 'sample_topic.minimal.xml'
-    mapping_path = tmp_path / 'intermediate' / 'sample_topic.tag_mappings.txt'
+    minimal_path = tmp_path / "intermediate" / "sample_topic.minimal.xml"
+    mapping_path = tmp_path / "intermediate" / "sample_topic.tag_mappings.txt"
     assert minimal_path.exists() and mapping_path.exists()
-    with open(seg_path, 'r', encoding='utf-8') as f:
+    with open(seg_path, "r", encoding="utf-8") as f:
         data = json.load(f)
-    assert all(len(entry['id']) == config.ID_LENGTH for entry in data)
+    assert all(len(entry["id"]) == config.ID_LENGTH for entry in data)
 
 
 def test_generate_dummy_translation_and_integrate(tmp_path):
     tr = make_transformer(tmp_path)
     segments, _ = tr.parse(SAMPLE_XML)
-    seg_path = tmp_path / 'intermediate' / 'sample_topic.en-US_segments.json'
-    dummy_path = tmp_path / 'intermediate' / 'sample_topic.translated.json'
+    seg_path = tmp_path / "intermediate" / "sample_topic.en-US_segments.json"
+    dummy_path = tmp_path / "intermediate" / "sample_topic.translated.json"
     tr.generate_dummy_translation(str(seg_path), str(dummy_path))
-    with open(dummy_path, 'r', encoding='utf-8') as f:
+    with open(dummy_path, "r", encoding="utf-8") as f:
         entries = json.load(f)
-    assert entries[0]['de-DE'].startswith('[de-DE_1]')
+    assert entries[0]["de-DE"].startswith("[de-DE_1]")
     target_path = tr.integrate(str(dummy_path))
     assert os.path.exists(target_path)
 
@@ -72,57 +73,106 @@ def test_generate_dummy_translation_and_integrate(tmp_path):
 def test_validate_passes_for_generated_files(tmp_path):
     tr = make_transformer(tmp_path)
     tr.parse(SAMPLE_XML)
-    seg_path = tmp_path / 'intermediate' / 'sample_topic.en-US_segments.json'
-    dummy_path = tmp_path / 'intermediate' / 'sample_topic.translated.json'
+    seg_path = tmp_path / "intermediate" / "sample_topic.en-US_segments.json"
+    dummy_path = tmp_path / "intermediate" / "sample_topic.translated.json"
     tr.generate_dummy_translation(str(seg_path), str(dummy_path))
     target_path = tr.integrate(str(dummy_path))
     report = tr.validate(SAMPLE_XML, target_path)
     assert report.passed
 
+
 def test_write_minimal_creates_placeholders(tmp_path):
     tr = make_transformer(tmp_path)
     tr.parse(SAMPLE_XML)
-    minimal_path = tmp_path / 'intermediate' / 'sample_topic.minimal.xml'
-    mapping_path = tmp_path / 'intermediate' / 'sample_topic.tag_mappings.txt'
-    with open(minimal_path, 'r', encoding='utf-8') as f:
+    minimal_path = tmp_path / "intermediate" / "sample_topic.minimal.xml"
+    mapping_path = tmp_path / "intermediate" / "sample_topic.tag_mappings.txt"
+    with open(minimal_path, "r", encoding="utf-8") as f:
         content = f.read()
-    assert '<t1>' in content
-    assert '_data-dita-seg-id' not in content  # tags replaced but attribute kept
+    assert "<t1>" in content
+    assert "_data-dita-seg-id" not in content  # tags replaced but attribute kept
     # ensure same placeholder used for all <p> elements
     mappings = {}
-    with open(mapping_path, 'r', encoding='utf-8') as f:
+    with open(mapping_path, "r", encoding="utf-8") as f:
         for line in f:
-            ph, tag = line.strip().split(' -> ')
+            ph, tag = line.strip().split(" -> ")
             mappings[tag] = ph
-    p_placeholder = mappings.get('p')
+    p_placeholder = mappings.get("p")
     assert p_placeholder is not None
-    assert content.count(f'<{p_placeholder}_') >= 4  # multiple <p> tags share placeholder
+    assert content.count(f"<{p_placeholder}_") >= 4  # multiple <p> tags share placeholder
 
 
 def test_has_inline_child_false(tmp_path):
     tr = make_transformer(tmp_path)
-    elem = etree.fromstring('<p>Just text</p>')
+    elem = etree.fromstring("<p>Just text</p>")
     assert not utils.has_inline_child(elem)
 
 
 def test_is_container_false_for_inline(tmp_path):
     tr = make_transformer(tmp_path)
-    inline = etree.fromstring('<b>bold</b>')
+    inline = etree.fromstring("<b>bold</b>")
     assert not utils.is_container(inline)
 
 
 def test_validate_detects_mismatch(tmp_path):
     tr = make_transformer(tmp_path)
     tr.parse(SAMPLE_XML)
-    seg_path = tmp_path / 'intermediate' / 'sample_topic.en-US_segments.json'
-    dummy_path = tmp_path / 'intermediate' / 'sample_topic.translated.json'
+    seg_path = tmp_path / "intermediate" / "sample_topic.en-US_segments.json"
+    dummy_path = tmp_path / "intermediate" / "sample_topic.translated.json"
     tr.generate_dummy_translation(str(seg_path), str(dummy_path))
     target_path = tr.integrate(str(dummy_path))
     # modify the file to break validation
-    with open(target_path, 'r+', encoding='utf-8') as f:
-        content = f.read().replace('<title>', '<title changed="1">')
+    with open(target_path, "r+", encoding="utf-8") as f:
+        content = f.read().replace("<title>", '<title changed="1">')
         f.seek(0)
         f.write(content)
         f.truncate()
     report = tr.validate(SAMPLE_XML, target_path)
     assert not report.passed
+
+
+def test_parse_with_basename_and_dirs(tmp_path):
+    tr = make_transformer(tmp_path)
+    segments, skeleton = tr.parse("sample_topic.xml")
+    assert len(segments) == 9
+    assert os.path.exists(skeleton)
+    seg_path = tmp_path / "intermediate" / "sample_topic.en-US_segments.json"
+    assert seg_path.exists()
+
+
+def test_parse_and_integrate_without_dirs(tmp_path):
+    xml_abs = os.path.abspath(SAMPLE_XML)
+    skel = tmp_path / "skel.xml"
+    segs = tmp_path / "segs.json"
+    translated = tmp_path / "translated.json"
+    out_xml = tmp_path / "out.xml"
+    tr = Dita2LLM(None, None, None)
+    segments, skeleton_path = tr.parse(xml_abs, skeleton_path=str(skel), segments_path=str(segs))
+    assert skeleton_path == str(skel)
+    tr.generate_dummy_translation(str(segs), str(translated))
+    target = tr.integrate(str(translated), skeleton_path=str(skel), output_path=str(out_xml))
+    report = tr.validate(xml_abs, target)
+    assert report.passed
+
+
+def test_generate_dummy_and_integrate_with_basenames(tmp_path):
+    tr = make_transformer(tmp_path)
+    tr.parse("sample_topic.xml")
+    tr.generate_dummy_translation(
+        "sample_topic.en-US_segments.json",
+        "sample_topic.translated.json",
+    )
+    target = tr.integrate("sample_topic.translated.json")
+    assert os.path.exists(target)
+    assert target.endswith("sample_topic.xml")
+
+
+def test_validate_with_basenames(tmp_path):
+    tr = make_transformer(tmp_path)
+    tr.parse("sample_topic.xml")
+    tr.generate_dummy_translation(
+        "sample_topic.en-US_segments.json",
+        "sample_topic.translated.json",
+    )
+    tr.integrate("sample_topic.translated.json")
+    report = tr.validate("sample_topic.xml", "sample_topic.xml")
+    assert report.passed


### PR DESCRIPTION
## Summary
- allow `Dita2LLM` directories to be optional
- add helper to resolve filenames against configured directories
- support overriding output paths in `parse` and `integrate`
- update `generate_dummy_translation`, `validate`, and simple XML integration
- expand unit tests for new behaviour
- document how to call the API with or without configured directories

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840bb69c67c8320a2b52d6cbb6ac6cf