### PR TITLE
Refactor validation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ pytest
 ```
 dita_xml_parser/
 ├── transformer.py  # Dita2LLM main workflow class
+├── validator.py    # XML structure validation utilities
 ├── utils.py        # helper functions for XML manipulation
 ├── minimal.py      # create minimal placeholder XML files
-└── __init__.py     # exposes Dita2LLM for import
+└── __init__.py     # exposes package classes for import
 ```
 
 Example DITA files are provided in `sample_data/` and unit tests live in `tests/`.

--- a/dita_xml_parser/__init__.py
+++ b/dita_xml_parser/__init__.py
@@ -6,5 +6,6 @@ allows ``from dita_xml_parser import Dita2LLM`` to work for novice users.
 """
 
 from .transformer import Dita2LLM
+from .validator import DitaValidator, ValidationReport
 
-__all__ = ["Dita2LLM"]
+__all__ = ["Dita2LLM", "DitaValidator", "ValidationReport"]

--- a/dita_xml_parser/minimal.py
+++ b/dita_xml_parser/minimal.py
@@ -8,10 +8,15 @@ from typing import Dict
 
 from lxml import etree
 
-import config
 
 
-def write_minimal(tree: etree._ElementTree, base: str, intermediate_dir: str, encoding: str, logger) -> None:
+def write_minimal(
+    tree: etree._ElementTree,
+    base: str,
+    intermediate_dir: str,
+    encoding: str,
+    logger,
+) -> None:
     """Create a minimal placeholder version of ``tree`` for the LLM."""
     minimal = copy.deepcopy(tree)
 

--- a/dita_xml_parser/transformer.py
+++ b/dita_xml_parser/transformer.py
@@ -6,7 +6,7 @@ import datetime
 import json
 import logging
 import os
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
 
 from lxml import etree
@@ -14,14 +14,9 @@ from lxml import etree
 import config
 from . import minimal
 from . import utils
+from .validator import DitaValidator, ValidationReport
 
 
-class ValidationReport:
-    """Simple container for validation results."""
-
-    def __init__(self, passed: bool, details: List[str]) -> None:
-        self.passed = passed
-        self.details = details
 
 
 class Dita2LLM:
@@ -49,6 +44,7 @@ class Dita2LLM:
         os.makedirs(self.log_dir, exist_ok=True)
         self.logger = logging.getLogger("Dita2LLM")
         self.logger.setLevel(getattr(logging, config.LOG_LEVEL))
+        self.validator = DitaValidator(self.logger)
         # Path to the most recently generated target file
         self._last_target_path: str | None = None
         self._log_path: str | None = None
@@ -175,7 +171,7 @@ class Dita2LLM:
                 seg_id, value = next(iter(entry.items()))
             elems = root.xpath(f"//*[@data-dita-seg-id='{seg_id}']")
             if not elems:
-                self.logger.error(f"ID {seg_id} not found in skeleton")
+                self.logger.error("ID %s not found in skeleton", seg_id)
                 continue
             elem = elems[0]
             utils.set_inner_xml(elem, value)
@@ -196,8 +192,8 @@ class Dita2LLM:
             pretty_print=True,
         )
         self._last_target_path = target_path
-        self.logger.info(f"Skeleton used: {skeleton_path}")
-        self.logger.info(f"Wrote integrated file: {target_path}")
+        self.logger.info("Skeleton used: %s", skeleton_path)
+        self.logger.info("Wrote integrated file: %s", target_path)
         self.logger.info("End integrate")
         return target_path
 
@@ -206,69 +202,8 @@ class Dita2LLM:
 
         src_xml = self._resolve(src_xml, self.source_dir)
         tgt_xml = self._resolve(tgt_xml, self.target_dir)
-        self.logger.info("Start validate: %s vs %s", src_xml, tgt_xml)
-        parser = etree.XMLParser(remove_blank_text=False)
-        try:
-            src_tree = etree.parse(src_xml, parser)
-            tgt_tree = etree.parse(tgt_xml, parser)
-        except Exception as e:
-            self.logger.error(f"Validation parse error: {e}")
-            return ValidationReport(False, [str(e)])
-        errors = []
-        warnings: List[str] = []
-        if src_tree.docinfo.doctype != tgt_tree.docinfo.doctype:
-            errors.append("DOCTYPE changed")
-
-        def walk(e1, e2, path=""):
-            if isinstance(e1.tag, str) and isinstance(e2.tag, str):
-                if e1.tag != e2.tag:
-                    errors.append(f"tag mismatch at {path}/{e1.tag}")
-                    return
-                if e1.attrib != e2.attrib:
-                    errors.append(f"attrib mismatch at {path}/{e1.tag}")
-                children1 = list(e1)
-                children2 = list(e2)
-                if len(children1) != len(children2):
-                    errors.append(f"child count mismatch at {path}/{e1.tag}")
-                for c1, c2 in zip(children1, children2):
-                    walk(c1, c2, path + "/" + e1.tag)
-            elif isinstance(e1, etree._Comment) and isinstance(e2, etree._Comment):
-                if e1.text != e2.text:
-                    errors.append(f"comment mismatch at {path}")
-            elif isinstance(e1, etree._ProcessingInstruction) and isinstance(
-                e2, etree._ProcessingInstruction
-            ):
-                if e1.target != e2.target or e1.text != e2.text:
-                    errors.append(f"pi mismatch at {path}")
-
-        walk(src_tree.getroot(), tgt_tree.getroot())
-
-        base = os.path.splitext(os.path.basename(src_xml))[0]
         skel_dir = self.intermediate_dir or os.path.dirname(tgt_xml)
-        skeleton_path = os.path.join(skel_dir, f"{base}.skeleton.xml")
-        if os.path.exists(skeleton_path):
-            skel_tree = etree.parse(skeleton_path, parser)
-            skel_et = etree.ElementTree(skel_tree.getroot())
-            for seg_elem in skel_tree.xpath("//*[@data-dita-seg-id]"):
-                seg_id = seg_elem.get("data-dita-seg-id")
-                xpath = skel_et.getpath(seg_elem)
-                src_match = src_tree.xpath(xpath)
-                tgt_match = tgt_tree.xpath(xpath)
-                if src_match and tgt_match:
-                    s_inner = utils.get_inner_xml(src_match[0]).strip()
-                    t_inner = utils.get_inner_xml(tgt_match[0]).strip()
-                    if s_inner == t_inner and s_inner:
-                        msg = f"Untranslated segment {seg_id} at {xpath}"
-                        warnings.append(msg)
-                        self.logger.warning(msg)
-
-        passed = not errors
-        for err in errors:
-            self.logger.error(err)
-        for warn in warnings:
-            self.logger.warning(warn)
-        self.logger.info("End validate")
-        return ValidationReport(passed, errors + warnings)
+        return self.validator.validate(src_xml, tgt_xml, skel_dir)
 
     def generate_dummy_translation(self, segments_json_path: str, output_path: str) -> str:
         segments_json_path = self._resolve(segments_json_path, self.intermediate_dir)
@@ -311,7 +246,7 @@ class Dita2LLM:
             Path to the generated translated XML and the validation report.
         """
         simple_xml_path = self._resolve(simple_xml_path, self.intermediate_dir)
-        self.logger.info(f"Start integrate from simple XML: {simple_xml_path}")
+        self.logger.info("Start integrate from simple XML: %s", simple_xml_path)
 
         name = os.path.splitext(os.path.basename(simple_xml_path))[0]
         if ".minimal" in name:

--- a/dita_xml_parser/validator.py
+++ b/dita_xml_parser/validator.py
@@ -1,0 +1,111 @@
+"""Validation utilities for DITA XML files."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import List
+
+from lxml import etree
+
+import config
+from . import utils
+
+
+class ValidationReport:
+    """Simple container for validation results."""
+
+    def __init__(self, passed: bool, details: List[str]):
+        self.passed = passed
+        self.details = details
+
+
+class DitaValidator:
+    """Validate translated XML against the source structure."""
+
+    def __init__(self, logger: logging.Logger | None = None):
+        self.logger = logger or logging.getLogger(__name__)
+
+    def validate(
+        self,
+        src_xml: str,
+        tgt_xml: str,
+        skeleton_dir: str | None = None,
+    ) -> ValidationReport:
+        """Validate that ``tgt_xml`` matches ``src_xml`` structure."""
+        self.logger.info("Start validate: %s vs %s", src_xml, tgt_xml)
+
+        if not os.path.exists(src_xml):
+            msg = f"Source XML not found: {src_xml}"
+            self.logger.error(msg)
+            return ValidationReport(False, [msg])
+        if not os.path.exists(tgt_xml):
+            msg = f"Target XML not found: {tgt_xml}"
+            self.logger.error(msg)
+            return ValidationReport(False, [msg])
+
+        parser = etree.XMLParser(remove_blank_text=False)
+        try:
+            src_tree = etree.parse(src_xml, parser)
+            tgt_tree = etree.parse(tgt_xml, parser)
+        except Exception as exc:  # pragma: no cover - unexpected parse error
+            self.logger.error("Validation parse error: %s", exc)
+            return ValidationReport(False, [str(exc)])
+
+        errors: List[str] = []
+        warnings: List[str] = []
+
+        if src_tree.docinfo.doctype != tgt_tree.docinfo.doctype:
+            errors.append("DOCTYPE changed")
+
+        def walk(e1: etree._Element, e2: etree._Element, path: str = "") -> None:
+            if isinstance(e1.tag, str) and isinstance(e2.tag, str):
+                if e1.tag != e2.tag:
+                    errors.append(f"tag mismatch at {path}/{e1.tag}")
+                    return
+                if e1.attrib != e2.attrib:
+                    errors.append(f"attrib mismatch at {path}/{e1.tag}")
+                children1 = list(e1)
+                children2 = list(e2)
+                if len(children1) != len(children2):
+                    errors.append(f"child count mismatch at {path}/{e1.tag}")
+                for c1, c2 in zip(children1, children2):
+                    walk(c1, c2, path + "/" + e1.tag)
+            elif isinstance(e1, etree._Comment) and isinstance(e2, etree._Comment):
+                if e1.text != e2.text:
+                    errors.append(f"comment mismatch at {path}")
+            elif isinstance(e1, etree._ProcessingInstruction) and isinstance(
+                e2, etree._ProcessingInstruction
+            ):
+                if e1.target != e2.target or e1.text != e2.text:
+                    errors.append(f"pi mismatch at {path}")
+
+        walk(src_tree.getroot(), tgt_tree.getroot())
+
+        base = os.path.splitext(os.path.basename(src_xml))[0]
+        skel_dir = skeleton_dir or os.path.dirname(tgt_xml)
+        skeleton_path = os.path.join(skel_dir, f"{base}.skeleton.xml")
+        if os.path.exists(skeleton_path):
+            skel_tree = etree.parse(skeleton_path, parser)
+            skel_et = etree.ElementTree(skel_tree.getroot())
+            for seg_elem in skel_tree.xpath("//*[@data-dita-seg-id]"):
+                seg_id = seg_elem.get("data-dita-seg-id")
+                xpath = skel_et.getpath(seg_elem)
+                src_match = src_tree.xpath(xpath)
+                tgt_match = tgt_tree.xpath(xpath)
+                if src_match and tgt_match:
+                    s_inner = utils.get_inner_xml(src_match[0]).strip()
+                    t_inner = utils.get_inner_xml(tgt_match[0]).strip()
+                    if s_inner == t_inner and s_inner:
+                        msg = f"Untranslated segment {seg_id} at {xpath}"
+                        warnings.append(msg)
+                        self.logger.warning(msg)
+
+        passed = not errors
+        for err in errors:
+            self.logger.error(err)
+        for warn in warnings:
+            self.logger.warning(warn)
+        self.logger.info("End validate")
+        return ValidationReport(passed, errors + warnings)
+


### PR DESCRIPTION
## Summary
- refactor validation code into new `validator.py`
- add `DitaValidator` usage in `Dita2LLM`
- clean up logging and typing
- document the new module in README

## Testing
- `pycodestyle dita_xml_parser/`
- `pylint dita_xml_parser/`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68414b0a1b2c832097ea6ac0f684d198