### PR TITLE
Refactor code to satisfy pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -2,22 +2,4 @@
 extension-pkg-whitelist=lxml
 
 [MESSAGES CONTROL]
-disable=
-    C0114,
-    C0115,
-    C0116,
-    C0305,
-    W0611,
-    W0612,
-    W0212,
-    W0718,
-    W1203,
-    R0902,
-    R0903,
-    R0913,
-    R0914,
-    R0915,
-    R0912,
-    R0917,
-    C0415,
-    I1101
+disable=W0212,R0914

--- a/README.md
+++ b/README.md
@@ -62,11 +62,9 @@ tr.generate_dummy_translation(
     "sample_topic.translated.json",
 )
 
-# Merge translations back into the skeleton
-tr.integrate("sample_topic.translated.json")
-
-# Validate the result
-report = tr.validate("sample_topic.xml", tr._last_target_path)
+# Merge translations back into the skeleton and validate the result
+target_path = tr.integrate("sample_topic.translated.json")
+report = tr.validate("sample_topic.xml", target_path)
 print("validation", "passed" if report.passed else "failed")
 ```
 


### PR DESCRIPTION
## Summary
- tighten `.pylintrc` leaving only two disabled checks
- refactor `Dita2LLM` to reduce arguments and instance attributes
- add helper methods for translation and mapping logic
- restructure `DitaValidator` as dataclass and add utility methods
- update README example
- ensure all tests pass and pylint score is 10/10

## Testing
- `pylint dita_xml_parser`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68414df948ec8320b5afd89536d5831f