### PR TITLE
Fix parse failing on comments

### DIFF
--- a/dita_xml_parser/minimal.py
+++ b/dita_xml_parser/minimal.py
@@ -40,12 +40,17 @@ def write_minimal(
     :param logger: Logger for progress messages.
     :returns: ``None``. Files are written for later stages.
     """
-    minimal = copy.deepcopy(tree)
+    # copy only the root element to avoid preserving top-level comments and PIs
+    minimal = etree.ElementTree(copy.deepcopy(tree.getroot()))
 
-    for el in minimal.xpath("//comment()"):
-        el.getparent().remove(el)
-    for el in minimal.xpath("//processing-instruction()"):
-        el.getparent().remove(el)
+    for el in minimal.xpath("//comment()"): 
+        parent = el.getparent()
+        if parent is not None:
+            parent.remove(el)
+    for el in minimal.xpath("//processing-instruction()"): 
+        parent = el.getparent()
+        if parent is not None:
+            parent.remove(el)
 
     placeholder_map: Dict[str, str] = {}
     tag_to_placeholder: Dict[str, str] = {}

--- a/dita_xml_parser/transformer.py
+++ b/dita_xml_parser/transformer.py
@@ -277,7 +277,9 @@ class Dita2LLM:
         root = tree.getroot()
         ids: List[Tuple[etree._Element, str]] = []
         count = 0
-        for elem in root.iter():
+        # Only iterate over element nodes to avoid comments and processing
+        # instructions which do not support attributes.
+        for elem in root.iter("*"):
             if utils.is_container(elem):
                 if "data-dita-seg-id" not in elem.attrib:
                     seg_id = utils.generate_id()

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import logging
+import io
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from lxml import etree
@@ -38,6 +39,18 @@ def test_write_minimal_strips_comments_and_pi(tmp_path):
     out = (tmp_path / 'x.minimal.xml').read_text(encoding='utf-8')
     assert '<!--' not in out
     assert '<?proc' not in out
+
+
+def test_write_minimal_handles_top_level_comments(tmp_path):
+    xml = '<!--top--><?pi?><topic>t</topic>'
+    parser = etree.XMLParser(remove_blank_text=False)
+    tree = etree.parse(io.StringIO(xml), parser)
+    logger = logging.getLogger("test")
+    # Should not raise when removing comments without a parent
+    minimal.write_minimal(tree, 'y', str(tmp_path), 'utf-8', logger)
+    out = (tmp_path / 'y.minimal.xml').read_text(encoding='utf-8')
+    assert '<!--' not in out
+    assert '<?pi' not in out
 
 
 def test_is_container_with_tail_text():


### PR DESCRIPTION
## Summary
- copy root element only to drop top-level comments
- skip removal for comments and processing instructions with no parent
- add regression test for top-level comments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415f8ba72c83208d310b84fb5235f1