### PR TITLE
Add do-not-translate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Example DITA files are provided in `sample_data/` and unit tests live in `tests/
 - Merges translated content back into the original file
 - Validates the output to ensure structural fidelity
 - Supports configuration via a small ``TOML`` file
+- Allows exclusion of tags that must remain in the source language
 
 ## Basic usage
 
@@ -96,6 +97,11 @@ When translating the minimal XML directly, edit
 `sample_topic.tag_mappings.txt` and `sample_topic.skeleton.xml` files in the
 same directory and produces the final `sample_topic.xml` in the target folder.
 
+When ``DO_NOT_TRANSLATE`` tags are configured, `parse()` also creates a
+`*.dnt.json` file mapping the placeholder IDs to the original element name and
+text.  All ``<dnt>`` placeholders are restored automatically during
+integration so that their content remains in the source language.
+
 The overall workflow therefore looks like this:
 
 1. `parse()` → creates `*.skeleton.xml`, `*.<src>_segments.json`, `*.minimal.xml`
@@ -125,6 +131,7 @@ or place ``config.toml`` next to ``config.py``. The following keys are
 supported:
 
 - ``INLINE_TAGS``: list of inline element names
+- ``DO_NOT_TRANSLATE``: tags to replace with ``<dnt>`` placeholders
 - ``ID_LENGTH``: length of generated segmentation IDs
 - ``LOG_LEVEL``: default logger level
 

--- a/config.py
+++ b/config.py
@@ -38,6 +38,16 @@ INLINE_TAGS = {
     "code",
 }
 
+# Tags that should be preserved in the source language and not exposed to
+# translation.  The content of these elements is replaced with a ``<dnt>``
+# placeholder during parsing and later restored using an ID based mapping.
+DO_NOT_TRANSLATE = {
+    "uicontrol",
+    "menucascade",
+    "cite",
+    "ph",
+}
+
 # Each translatable container gets a hex id of this length. Twelve digits give
 # over a trillion possibilities which is enough for temporary identifiers.
 ID_LENGTH: int = 12
@@ -47,5 +57,6 @@ LOG_LEVEL: str = "INFO"
 
 # Override with TOML values if provided
 INLINE_TAGS = set(_CONF.get("INLINE_TAGS", INLINE_TAGS))
+DO_NOT_TRANSLATE = set(_CONF.get("DO_NOT_TRANSLATE", DO_NOT_TRANSLATE))
 ID_LENGTH = int(_CONF.get("ID_LENGTH", ID_LENGTH))
 LOG_LEVEL = _CONF.get("LOG_LEVEL", LOG_LEVEL)

--- a/tests/test_config_toml.py
+++ b/tests/test_config_toml.py
@@ -8,6 +8,7 @@ def test_config_from_toml(tmp_path, monkeypatch):
 INLINE_TAGS = ["b", "i", "u"]
 ID_LENGTH = 8
 LOG_LEVEL = "DEBUG"
+DO_NOT_TRANSLATE = ["foo", "bar"]
 """)
     monkeypatch.setenv("DITA_PARSER_CONFIG", str(cfg))
     import config
@@ -15,5 +16,6 @@ LOG_LEVEL = "DEBUG"
     assert config.ID_LENGTH == 8
     assert config.LOG_LEVEL == "DEBUG"
     assert "b" in config.INLINE_TAGS
+    assert "foo" in config.DO_NOT_TRANSLATE
     monkeypatch.delenv("DITA_PARSER_CONFIG")
     importlib.reload(config)

--- a/tests/test_do_not_translate.py
+++ b/tests/test_do_not_translate.py
@@ -1,0 +1,72 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from lxml import etree
+from dita_xml_parser import Dita2LLM
+
+
+def make_transformer(tmp_path):
+    intermediate = tmp_path / "intermediate"
+    target = tmp_path / "translated"
+    intermediate.mkdir()
+    target.mkdir()
+    return Dita2LLM(str(tmp_path), str(intermediate), str(target))
+
+
+def create_xml(tmp_path):
+    xml = (
+        "<?xml version='1.0'?><topic><body>"
+        "<p>Press <uicontrol>OK</uicontrol> now.</p>"
+        "</body></topic>"
+    )
+    path = tmp_path / "dnt.xml"
+    path.write_text(xml, encoding="utf-8")
+    return path
+
+
+def test_dnt_not_in_segments(tmp_path):
+    tr = make_transformer(tmp_path)
+    xml_path = create_xml(tmp_path)
+    segments, _ = tr.parse(str(xml_path))
+    assert all("<uicontrol>" not in s[tr.source_lang] for s in segments)
+    skel = tmp_path / "intermediate" / "dnt.skeleton.xml"
+    tree = etree.parse(str(skel))
+    dnt = tree.xpath("//dnt")[0]
+    assert dnt.get("element") == "uicontrol"
+    assert dnt.get("content") == "OK"
+
+
+def test_dnt_restored_from_json(tmp_path):
+    tr = make_transformer(tmp_path)
+    xml_path = create_xml(tmp_path)
+    tr.parse(str(xml_path))
+    seg_path = tmp_path / "intermediate" / "dnt.en-US_segments.json"
+    out_path = tmp_path / "intermediate" / "dnt.translated.json"
+    tr.generate_dummy_translation(str(seg_path), str(out_path))
+    skel = tmp_path / "intermediate" / "dnt.skeleton.xml"
+    tree = etree.parse(str(skel))
+    dnt = tree.xpath("//dnt")[0]
+    dnt.set("content", "CHANGED")
+    tree.write(str(skel), encoding="utf-8")
+    target = tr.integrate(str(out_path))
+    final = etree.parse(str(target))
+    assert final.xpath("//uicontrol")[0].text == "OK"
+
+
+def test_dnt_restored_from_simple_xml(tmp_path):
+    tr = make_transformer(tmp_path)
+    xml_path = create_xml(tmp_path)
+    tr.parse(str(xml_path))
+    minimal = tmp_path / "intermediate" / "dnt.minimal.xml"
+    parser = etree.XMLParser(remove_blank_text=False)
+    tree = etree.parse(str(minimal), parser)
+    for el in tree.getroot().iter():
+        if el.text and el.text.strip():
+            el.text = "t " + el.text
+    trans_path = minimal.with_name(minimal.stem + ".translated.xml")
+    tree.write(str(trans_path), encoding="utf-8", pretty_print=True)
+    target, report = tr.integrate_from_simple_xml(str(trans_path))
+    assert report.passed
+    final = etree.parse(str(target))
+    assert final.xpath("//uicontrol")[0].text == "OK"
+

--- a/tests/test_simple_integration.py
+++ b/tests/test_simple_integration.py
@@ -28,7 +28,9 @@ def build_translated_simple(minimal_path, mapping_path, reorder=True, remove_b=F
             ph, tag = line.strip().split(' -> ')
             mappings[ph] = tag
 
-    ph_ph = next(k for k, v in mappings.items() if v == 'ph')
+    ph_ph = next((k for k, v in mappings.items() if v == 'ph'), None)
+    if ph_ph is None:
+        ph_ph = next(k for k, v in mappings.items() if v == 'dnt')
     ph_sub = next(k for k, v in mappings.items() if v == 'sub')
     ph_p = next(k for k, v in mappings.items() if v == 'p')
     ph_b = next(k for k, v in mappings.items() if v == 'b')


### PR DESCRIPTION
## Summary
- allow configuring DO_NOT_TRANSLATE tags
- handle <dnt> placeholder replacement and restoration
- update integration logic and README
- test DO NOT translate workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859948ff67483208fc45781892ab042