### PR TITLE
Fix DNT placeholder restoration

### DIFF
--- a/dita_xml_parser/transformer.py
+++ b/dita_xml_parser/transformer.py
@@ -157,10 +157,10 @@ class Dita2LLM:
     def _restore_dnt(self, root: etree._Element, mapping_path: str) -> None:
         """Replace ``<dnt>`` placeholders with the original elements."""
 
-        if not os.path.exists(mapping_path):
-            return
-        with open(mapping_path, "r", encoding="utf-8") as f:
-            mapping = json.load(f)
+        mapping = {}
+        if os.path.exists(mapping_path):
+            with open(mapping_path, "r", encoding="utf-8") as f:
+                mapping = json.load(f)
         for dnt in root.xpath("//dnt[@id]"):
             dnt_id = dnt.get("id")
             orig = mapping.get(dnt_id, None)


### PR DESCRIPTION
## Summary
- handle missing `dnt` mapping file by falling back to attributes
- add tests for DNT integration without mapping file or missing id

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ab443c5d88320a24ec3eb9f76f556