### PR TITLE
Add test for uicontrol DNT integration

### DIFF
--- a/sample_data/insurance_manager.xml
+++ b/sample_data/insurance_manager.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
+<reference id="GUID-643908C7-E574-4144-99EA-5C39BF79E0D7" xml:lang="de">
+    <title id="GUID-1B84301C-E9A3-44E8-81FE-3310F4BFEE83">Insurance Manager</title>
+    <shortdesc>The <uicontrol>Insurance Control</uicontrol> option enables you to select policy options and diagnostic utilities.</shortdesc>
+    <refbody>
+        <section>
+            To enter <uicontrol>Insurance Control</uicontrol>, log into the insurance portal and navigate to the policy management section.
+            <table frame="all">
+                <title><uicontrol>Insurance Control</uicontrol> details</title>
+                <desc>This table provides the details of the options available on the <uicontrol>Insurance Control</uicontrol> screen.</desc>
+                <tgroup cols="2">
+                    <colspec colnum="1" colname="col1" colwidth="1.00*"/>
+                    <colspec colnum="2" colname="col2" colwidth="1.76*"/>
+                    <thead>
+                        <row>
+                            <entry colname="col1">Option</entry>
+                            <entry colname="col2">Description</entry>
+                        </row>
+                    </thead>
+                    <tbody>
+                        <row>
+                            <entry colname="col1"><uicontrol>Insurance Control</uicontrol></entry>
+                            <entry colname="col2">The system attempts to process policies starting with the first item in the policy order. If the attempt fails, the system continues with the next item in the policy order until the process is successful or no more policy options are found.</entry>
+                        </row>
+                        <row>
+                            <entry colname="col1"><uicontrol>Insurance Control</uicontrol></entry>
+                            <entry colname="col2">Enables you to access the policy menu, where you can select a one-time policy option to process.</entry>
+                        </row>
+                        <row>
+                            <entry colname="col1"><uicontrol>Insurance Control</uicontrol></entry>
+                            <entry colname="col2">Enables you to access <uicontrol>Insurance Control</uicontrol>.</entry>
+                        </row>
+                        <row>
+                            <entry colname="col1"><uicontrol>Insurance Control</uicontrol></entry>
+                            <entry colname="col2">Enables you to launch the <uicontrol>Insurance Control</uicontrol> menu such as Launch Diagnostics, Policy update File Explorer, Reboot System.</entry>
+                        </row>
+                    </tbody>
+                </tgroup>
+            </table>
+        </section>
+    </refbody>
+</reference>

--- a/tests/test_insurance_manager.py
+++ b/tests/test_insurance_manager.py
@@ -1,0 +1,29 @@
+import os
+import sys
+from lxml import etree
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dita_xml_parser import Dita2LLM
+
+INSURANCE_XML = os.path.join(os.path.dirname(__file__), '..', 'sample_data', 'insurance_manager.xml')
+
+
+def make_transformer(tmp_path):
+    intermediate = tmp_path / 'intermediate'
+    target = tmp_path / 'translated'
+    intermediate.mkdir()
+    target.mkdir()
+    return Dita2LLM('sample_data', str(intermediate), str(target))
+
+
+def test_insurance_uicontrol_preserved(tmp_path):
+    tr = make_transformer(tmp_path)
+    segments, _ = tr.parse(INSURANCE_XML)
+    assert len(segments) > 0
+    seg_path = tmp_path / 'intermediate' / 'insurance_manager.en-US_segments.json'
+    out_path = tmp_path / 'intermediate' / 'insurance_manager.translated.json'
+    tr.generate_dummy_translation(str(seg_path), str(out_path))
+    target_path = tr.integrate(str(out_path))
+    tree = etree.parse(str(target_path))
+    texts = [el.text for el in tree.xpath('//uicontrol')]
+    assert all(t == 'Insurance Control' for t in texts)


### PR DESCRIPTION
## Summary
- add Insurance Manager sample XML
- test that `uicontrol` elements remain untranslated after dummy translation workflow

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aba09347483208460a018849ee162